### PR TITLE
Fixed cmake scripts to build swig module directory prior to building the module

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -93,6 +93,9 @@ set( CMAKE_SWIG_OUTDIR ${MODULE_PATH}/${SWIG_MODULE} )
 #        testing shows that this ONLY works for the gpstk.py
 #        and does NOT work for the _gpstk.so
 #----------------------------------------
+add_custom_target(swig-make-directory ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULE_PATH}/gpstk)
+add_dependencies("_${SWIG_MODULE}" swig-make-directory)
 add_custom_command( TARGET "_${SWIG_MODULE}" POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "_${SWIG_MODULE}.so" ${CMAKE_SWIG_OUTDIR} )
 add_custom_command( TARGET "_${SWIG_MODULE}" POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${SWIG_MODULE}.py" ${CMAKE_SWIG_OUTDIR} )
 


### PR DESCRIPTION
Upstream commit: https://github.com/SGL-UT/GPSTk/commit/9a05e5ac777eddf9a9a23d83f10d64d2a07f00ca

For review by: @linustan @JJTriesHisBest 

**Before**
```
# ./build.sh -se
./build_setup.sh: line 130: git: command not found
./build_setup.sh: line 131: git: command not found
printf: usage: printf [-v var] format [arguments]
============================================================
cmake -DBUILD_PYTHON=ON -DPYTHON_EXECUTABLE=/usr/bin/python -DPYTHON_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local/gpstk -DBUILD_EXT=ON /usr/local/gpstk/GPSTk-901b6c9f7a56d6030ac8c415701fd986eefa0146
CMake Warning:
  Manually-specified variables were not used by the project:

    PYTHON_INSTALL_PREFIX


============================================================
make all -j 1
Error copying file (if different) from "/usr/local/gpstk/GPSTk-901b6c9f7a56d6030ac8c415701fd986eefa0146/swig/gpstk/__init__.py" to "/usr/local/gpstk/GPSTk-901b6c9f7a56d6030ac8c415701fd986eefa0146/build/3cbd744a6f59-/swig/module/gpstk/__init__.py".
make[2]: *** [swig/module/gpstk/__init__.py] Error 1
make[1]: *** [swig/CMakeFiles/module_files_target.dir/all] Error 2
make: *** [all] Error 2

Error 2 :-(
See /usr/local/gpstk/GPSTk-901b6c9f7a56d6030ac8c415701fd986eefa0146/build/3cbd744a6f59-/Testing/Temporary/LastTest.log for detailed test log
See /usr/local/gpstk/GPSTk-901b6c9f7a56d6030ac8c415701fd986eefa0146/build/3cbd744a6f59-/build.log for detailed build log
root@3cbd744a6f59:/usr/local/gpstk/GPSTk-901b6c9f7a56d6030ac8c415701fd986eefa0146# more swig/CMakeLists.txt 
```

**After**
```
# ./build.sh -se
./build_setup.sh: line 130: git: command not found
./build_setup.sh: line 131: git: command not found
printf: usage: printf [-v var] format [arguments]
============================================================
cmake -DBUILD_PYTHON=ON -DPYTHON_EXECUTABLE=/usr/bin/python -DPYTHON_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local/gpstk -DBUILD_EXT=ON /usr/local/gpstk/GPSTk-f2ab40fc2fe6dd4700e62016b975e3a08cceeeac
CMake Warning:
  Manually-specified variables were not used by the project:

    PYTHON_INSTALL_PREFIX


============================================================
make all -j 1
============================================================
make install -j 1

Tests not run.
See /usr/local/gpstk/GPSTk-f2ab40fc2fe6dd4700e62016b975e3a08cceeeac/build/3cbd744a6f59-/Testing/Temporary/LastTest.log for detailed test log
See /usr/local/gpstk/GPSTk-f2ab40fc2fe6dd4700e62016b975e3a08cceeeac/build/3cbd744a6f59-/build.log for detailed build log

GPSTk build done. :-)
Fri Sep 21 02:15:10 UTC 2018
```